### PR TITLE
bugfix: added extra case in conditional to ensure that selected items…

### DIFF
--- a/src/components/customized/select/select-12.tsx
+++ b/src/components/customized/select/select-12.tsx
@@ -61,11 +61,11 @@ export default function FancyMultiSelect() {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Backspace" && selected.length > 0) {
+      if (e.key === "Backspace" && inputValue === '' && selected.length > 0) {
         setSelected((prev) => prev.slice(0, -1));
       }
     },
-    [selected]
+    [selected, inputValue]
   );
 
   const filteredCountries = useMemo(


### PR DESCRIPTION
## A simple change to ensure that there is no user typed text in the input before removing the selected options, reference code: 

Line: 64 from this:
`if (e.key === "Backspace" && selected.length > 0) {`
to this:
`if (e.key === "Backspace" && inputValue === '' && selected.length > 0) {`

and 

Line: 68 from this:
`[selected]`
to this:
`[selected, inputValue]`

##### Example of problem prior to fix:
https://github.com/user-attachments/assets/8dede370-b501-41eb-8355-bfaa09a52dbd

##### After fix:
https://github.com/user-attachments/assets/afacc38d-1b32-447e-8db7-d1e81ec01daf

### Reason for contribution:
I don't think if there is text in the input the expected result when a user hits backspace is to remove the selected items 